### PR TITLE
Expose noAction callback

### DIFF
--- a/ClientExample/Program.cs
+++ b/ClientExample/Program.cs
@@ -51,7 +51,7 @@ namespace ClientExample
             {
                 while (true)
                 {
-                    wrapper.RunClientWithDeviceToken(token, hawkbitUrl + "/" + controlledId, onConfigRequest, onDeploymentAction, onCancelAction);
+                    wrapper.RunClientWithDeviceToken(token, hawkbitUrl + "/" + controlledId, onConfigRequest, onDeploymentAction, onCancelAction, onNoAction);
                     Console.WriteLine("\nClient restarted");
                 }
             });
@@ -65,7 +65,7 @@ namespace ClientExample
                 {
                     const string xApigToken = "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
                     var cert = File.ReadAllText(certFile);
-                    wrapper.RunClient(cert, provisioningUrl, xApigToken, onProvErrorAction, onProvSuccessAction, onConfigRequest, onDeploymentAction, onCancelAction);
+                    wrapper.RunClient(cert, provisioningUrl, xApigToken, onProvErrorAction, onProvSuccessAction, onConfigRequest, onDeploymentAction, onCancelAction, onNoAction);
                     Console.WriteLine("\nClient restarted");
                 }
             });
@@ -85,6 +85,11 @@ namespace ClientExample
         {
             Console.WriteLine($"\nCancelAction: actionId = {actionId}");
             return true;
+        }
+
+        private static void onNoAction()
+        {
+            Console.WriteLine("\nNoAction");
         }
 
         private static void onDeploymentAction(IntPtr artifact, DeploymentInfo info, out ClientResult result)

--- a/ClientExample/Properties/AssemblyInfo.cs
+++ b/ClientExample/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.1.0.0")]
-[assembly: AssemblyFileVersion("2.1.0.0")]
+[assembly: AssemblyVersion("2.2.0.0")]
+[assembly: AssemblyFileVersion("2.2.0.0")]

--- a/Up2dateDotNet/IWrapper.cs
+++ b/Up2dateDotNet/IWrapper.cs
@@ -5,6 +5,7 @@ namespace Up2dateDotNet
     public delegate void ConfigRequestFunc(IntPtr responseBuilder);
     public delegate void DeploymentActionFunc(IntPtr artifact, DeploymentInfo info, out ClientResult result);
     public delegate bool CancelActionFunc(int stopId);
+    public delegate void NoActionFunc();
     public delegate void ProvErrorCallbackFunc(string errorMessage);
     public delegate void ProvSuccessCallbackFunc(string up2DateEndpoint);
 
@@ -19,17 +20,20 @@ namespace Up2dateDotNet
             ProvSuccessCallbackFunc onProvSuccessAction,
             ConfigRequestFunc configRequest,
             DeploymentActionFunc deploymentAction,
-            CancelActionFunc cancelAction);
+            CancelActionFunc cancelAction,
+            NoActionFunc noAction);
 
         void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint,
             ConfigRequestFunc configRequest,
             DeploymentActionFunc deploymentAction,
-            CancelActionFunc cancelAction);
+            CancelActionFunc cancelAction,
+            NoActionFunc noAction);
 
         void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoint,
             ConfigRequestFunc configRequest,
             DeploymentActionFunc deploymentAction,
-            CancelActionFunc cancelAction);
+            CancelActionFunc cancelAction,
+            NoActionFunc noAction);
 
         void StopClient();
 

--- a/Up2dateDotNet/Up2dateDotNet.csproj
+++ b/Up2dateDotNet/Up2dateDotNet.csproj
@@ -15,9 +15,9 @@
     <PackageTags>RITMS;UP2DATE</PackageTags>
     <PackageReleaseNotes>First public release.</PackageReleaseNotes>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <AssemblyVersion>2.1.0.0</AssemblyVersion>
-    <FileVersion>2.1.0.0</FileVersion>
-    <Version>2.1.0.0</Version>
+    <AssemblyVersion>2.2.0.0</AssemblyVersion>
+    <FileVersion>2.2.0.0</FileVersion>
+    <Version>2.2.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Up2dateDotNet/Wrapper.cs
+++ b/Up2dateDotNet/Wrapper.cs
@@ -29,39 +29,39 @@ namespace Up2dateDotNet
             }
         }
 
-        public void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction)
+        public void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction)
         {
             if (IntPtr.Size == 4)
             {
-                Wrapper32.RunClient(clientCertificate, provisioningEndpoint, xApigToken, onProvErrorAction, onProvSuccessAction, configRequest, deploymentAction, cancelAction);
+                Wrapper32.RunClient(clientCertificate, provisioningEndpoint, xApigToken, onProvErrorAction, onProvSuccessAction, configRequest, deploymentAction, cancelAction, noAction);
             }
             else
             {
-                Wrapper64.RunClient(clientCertificate, provisioningEndpoint, xApigToken, onProvErrorAction, onProvSuccessAction, configRequest, deploymentAction, cancelAction);
+                Wrapper64.RunClient(clientCertificate, provisioningEndpoint, xApigToken, onProvErrorAction, onProvSuccessAction, configRequest, deploymentAction, cancelAction, noAction);
             }
         }
 
-        public void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction)
+        public void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction)
         {
             if (IntPtr.Size == 4)
             {
-                Wrapper32.RunClientWithDeviceToken(deviceToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction);
+                Wrapper32.RunClientWithDeviceToken(deviceToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction, noAction);
             }
             else
             {
-                Wrapper64.RunClientWithDeviceToken(deviceToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction);
+                Wrapper64.RunClientWithDeviceToken(deviceToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction, noAction);
             }
         }
 
-        public void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction)
+        public void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction)
         {
             if (IntPtr.Size == 4)
             {
-                Wrapper32.RunClientWithDeviceToken(gatewayToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction);
+                Wrapper32.RunClientWithDeviceToken(gatewayToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction, noAction);
             }
             else
             {
-                Wrapper64.RunClientWithDeviceToken(gatewayToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction);
+                Wrapper64.RunClientWithDeviceToken(gatewayToken, hawkbitEndpoint, configRequest, deploymentAction, cancelAction, noAction);
             }
         }
 
@@ -99,13 +99,13 @@ namespace Up2dateDotNet
         public static extern void AddConfigAttribute(IntPtr responseBuilder, string key, string value);
 
         [DllImport(@"wrapperdll-x64.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x64.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x64.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoin, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoin, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x64.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern void StopClient();
@@ -123,13 +123,13 @@ namespace Up2dateDotNet
         public static extern void AddConfigAttribute(IntPtr responseBuilder, string key, string value);
 
         [DllImport(@"wrapperdll-x86.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClient(string clientCertificate, string provisioningEndpoint, string xApigToken, ProvErrorCallbackFunc onProvErrorAction, ProvSuccessCallbackFunc onProvSuccessAction, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x86.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClientWithDeviceToken(string deviceToken, string hawkbitEndpoint, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x86.dll", CallingConvention = CallingConvention.Cdecl)]
-        public static extern void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoin, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction);
+        public static extern void RunClientWithGatewayToken(string gatewayToken, string hawkbitEndpoin, ConfigRequestFunc configRequest, DeploymentActionFunc deploymentAction, CancelActionFunc cancelAction, NoActionFunc noAction);
 
         [DllImport(@"wrapperdll-x86.dll", CallingConvention = CallingConvention.Cdecl)]
         public static extern void StopClient();

--- a/wrapperdll/CallbackDispatcher.cpp
+++ b/wrapperdll/CallbackDispatcher.cpp
@@ -95,6 +95,7 @@ namespace HkbClient {
     }
 
     void CallbackDispatcher::onNoActions() {
+        noAction();
     }
 
     void CallbackDispatcher::DeployArtifact(const std::shared_ptr<::Artifact> artifact, DEPLOYMENTINFO info, ClientResult& result )

--- a/wrapperdll/CallbackDispatcher.hpp
+++ b/wrapperdll/CallbackDispatcher.hpp
@@ -46,9 +46,10 @@ namespace HkbClient {
         const char* message;
     } ClientResult;
 
-    typedef void (__stdcall *ConfigRequestCallbackFunction)(ddi::ConfigResponseBuilder* responseBuilder);
-    typedef void (__stdcall *DeploymentActionCallbackFunction)(ddi::Artifact* artifact, _DEPLOYMENTINFO info, ClientResult& result);
-    typedef bool (__stdcall *CancelActionCallbackFunction)(int stopId);
+    typedef void(__stdcall* ConfigRequestCallbackFunction)(ddi::ConfigResponseBuilder* responseBuilder);
+    typedef void(__stdcall* DeploymentActionCallbackFunction)(ddi::Artifact* artifact, _DEPLOYMENTINFO info, ClientResult& result);
+    typedef bool(__stdcall* CancelActionCallbackFunction)(int stopId);
+    typedef bool(__stdcall* NoActionCallbackFunction)();
 
     typedef struct 
     {
@@ -102,10 +103,11 @@ namespace HkbClient {
 
         ~CallbackDispatcher() = default;
 
-        CallbackDispatcher(ConfigRequestCallbackFunction _configRequest, DeploymentActionCallbackFunction _deploymentAction, CancelActionCallbackFunction _cancelAction) {
+        CallbackDispatcher(ConfigRequestCallbackFunction _configRequest, DeploymentActionCallbackFunction _deploymentAction, CancelActionCallbackFunction _cancelAction, NoActionCallbackFunction _noAction) {
             configRequest = _configRequest;
             deploymentAction = _deploymentAction;
             cancelAction = _cancelAction;
+            noAction = _noAction;
         };
 
     private:
@@ -115,6 +117,7 @@ namespace HkbClient {
         ConfigRequestCallbackFunction configRequest;
         DeploymentActionCallbackFunction deploymentAction;
         CancelActionCallbackFunction cancelAction;
+        NoActionCallbackFunction noAction;
         std::vector<KEYVALUEPAIR> configInfo;
         std::string downloadLocation;
     };

--- a/wrapperdll/DPSInfoReloadHandler.hpp
+++ b/wrapperdll/DPSInfoReloadHandler.hpp
@@ -24,12 +24,17 @@ namespace HkbClient {
         void onAuthError(std::unique_ptr<AuthRestoreHandler> ptr) override {
             for (;;) {
                 try {
+                    std::cout << "==============================================" << std::endl;
+                    std::cout << "|DPSInfoReloadHandler| Starting provisioning..." << std::endl;
                     auto payload = client->doProvisioning();
+                    std::cout << "|DPSInfoReloadHandler|     ... done" << std::endl;
                     auto keyPair = payload->getKeyPair();
+                    std::cout << "|DPSInfoReloadHandler| Setting TLS ..." << std::endl;
                     ptr->setTLS(keyPair->getCrt(), keyPair->getKey());
                     auto endpoint = payload->getUp2DateEndpoint();
                     std::cout << "|DPSInfoReloadHandler| Setting endpoint [" << endpoint << "] ..." << std::endl;
                     ptr->setEndpoint(endpoint);
+                    std::cout << "==============================================" << std::endl;
                     provSuccessAction(endpoint.c_str());
                     return;
                 }

--- a/wrapperdll/DPSInfoReloadHandler.hpp
+++ b/wrapperdll/DPSInfoReloadHandler.hpp
@@ -28,6 +28,7 @@ namespace HkbClient {
                     auto keyPair = payload->getKeyPair();
                     ptr->setTLS(keyPair->getCrt(), keyPair->getKey());
                     auto endpoint = payload->getUp2DateEndpoint();
+                    std::cout << "|DPSInfoReloadHandler| Setting endpoint [" << endpoint << "] ..." << std::endl;
                     ptr->setEndpoint(endpoint);
                     provSuccessAction(endpoint.c_str());
                     return;

--- a/wrapperdll/ddiclient.cpp
+++ b/wrapperdll/ddiclient.cpp
@@ -21,7 +21,8 @@ namespace HkbClient {
         ProvSuccessCallbackFunction provSuccessAction,
         ConfigRequestCallbackFunction configRequest,
         DeploymentActionCallbackFunction deploymentAction,
-        CancelActionCallbackFunction cancelAction) {
+        CancelActionCallbackFunction cancelAction,
+        NoActionCallbackFunction noAction) {
         auto dpsBuilder = CloudProvisioningClientBuilder::newInstance();
         auto dpsClient = dpsBuilder->setEndpoint(provisioningEndpoint)
             ->setAuthCrt(clientCertificate)
@@ -33,7 +34,7 @@ namespace HkbClient {
         auto builder = DDIClientBuilder::newInstance();
 
         client = builder->setAuthErrorHandler(authErrorHandler)
-            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction)))
+            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction, noAction)))
             ->build();
 
         client->run();
@@ -42,13 +43,14 @@ namespace HkbClient {
     void RunClientWithDeviceToken(const char* deviceToken, const char* hawkbitEndpoint,
         ConfigRequestCallbackFunction configRequest,
         DeploymentActionCallbackFunction deploymentAction,
-        CancelActionCallbackFunction cancelAction) {
+        CancelActionCallbackFunction cancelAction,
+        NoActionCallbackFunction noAction) {
 
         auto builder = DDIClientBuilder::newInstance();
 
         client = builder->setHawkbitEndpoint(hawkbitEndpoint)
             ->setDeviceToken(deviceToken)
-            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction)))
+            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction, noAction)))
             ->build();
 
         client->run();
@@ -57,13 +59,14 @@ namespace HkbClient {
     void RunClientWithGatewayToken(const char* gatewayToken, const char* hawkbitEndpoint,
         ConfigRequestCallbackFunction configRequest,
         DeploymentActionCallbackFunction deploymentAction,
-        CancelActionCallbackFunction cancelAction) {
+        CancelActionCallbackFunction cancelAction,
+        NoActionCallbackFunction noAction) {
 
         auto builder = DDIClientBuilder::newInstance();
 
         client = builder->setHawkbitEndpoint(hawkbitEndpoint)
             ->setGatewayToken(gatewayToken)
-            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction)))
+            ->setEventHandler(std::shared_ptr<EventHandler>(new CallbackDispatcher(configRequest, deploymentAction, cancelAction, noAction)))
             ->build();
 
         client->run();

--- a/wrapperdll/ddiclient.h
+++ b/wrapperdll/ddiclient.h
@@ -20,15 +20,18 @@ namespace HkbClient {
 			ProvSuccessCallbackFunction provSuccessAction,
 			ConfigRequestCallbackFunction configRequest,
 			DeploymentActionCallbackFunction deploymentAction,
-			CancelActionCallbackFunction cancelAction);
+			CancelActionCallbackFunction cancelAction,
+			NoActionCallbackFunction noAction);
 		WDLL_EXPORT void RunClientWithDeviceToken(const char* deviceToken, const char* hawkbitEndpoint,
 			ConfigRequestCallbackFunction configRequest,
 			DeploymentActionCallbackFunction deploymentAction,
-			CancelActionCallbackFunction cancelAction);
+			CancelActionCallbackFunction cancelAction,
+			NoActionCallbackFunction noAction);
 		WDLL_EXPORT void RunClientWithGatewayToken(const char* gatewayToken, const char* hawkbitEndpoint,
 			ConfigRequestCallbackFunction configRequest,
 			DeploymentActionCallbackFunction deploymentAction,
-			CancelActionCallbackFunction cancelAction);
+			CancelActionCallbackFunction cancelAction,
+			NoActionCallbackFunction noAction);
 		WDLL_EXPORT void StopClient();
 		WDLL_EXPORT void RequestToPoll();
 	}


### PR DESCRIPTION
* Expose (export) noAction callback. May be used by client, for instance, to indiretcly detect the moment of successful connection to server
* Add diagnostic console output
* Change version to 2.2.0